### PR TITLE
Adding react-dom/server to @esm-bundle/react-dom

### DIFF
--- a/browser-test/react-dom-server.test.js
+++ b/browser-test/react-dom-server.test.js
@@ -1,0 +1,33 @@
+describe("@esm-bundle/react-dom-server", () => {
+  it("can load the development ESM bundle", () => {
+    return import("/base/esm/react-dom-server.resolved.browser.development.js");
+  });
+
+  it("can load the production ESM bundle", () => {
+    return import(
+      "/base/esm/react-dom-server.resolved.browser.production.min.js"
+    );
+  });
+
+  it(`can load the systemJS development bundle`, () => {
+    return System.import(
+      "/base/system/react-dom-server.browser.development.js"
+    ).then((module) => {
+      expect(module.default).toBeDefined();
+      expect(module.__esModule).toBeDefined();
+      expect(typeof module.renderToString).toBe("function");
+      expect(typeof module.default.renderToString).toBe("function");
+    });
+  });
+
+  it(`can load the systemJS production bundle`, () => {
+    return System.import(
+      "/base/system/react-dom-server.browser.production.min.js"
+    ).then((module) => {
+      expect(module.default).toBeDefined();
+      expect(module.__esModule).toBeDefined();
+      expect(typeof module.renderToString).toBe("function");
+      expect(typeof module.default.renderToString).toBe("function");
+    });
+  });
+});

--- a/node-test/react-dom-server.test.mjs
+++ b/node-test/react-dom-server.test.mjs
@@ -1,0 +1,21 @@
+describe(`@esm-bundle/react-dom-server`, () => {
+  it("can load the esm bundle without dying", () => {
+    return import("../esm/react-dom-server.browser.development.js");
+  });
+
+  it(`has a renderToString method on development bundle`, async () => {
+    const ReactDomServer = await import(
+      "../esm/react-dom-server.browser.development.js"
+    );
+    expect(ReactDomServer.renderToString).not.to.equal(undefined);
+    expect(typeof ReactDomServer.renderToString).to.equal("function");
+  });
+
+  it(`has a renderToString method on the production bundle`, async () => {
+    const ReactDomServer = await import(
+      "../esm/react-dom-server.browser.production.min.js"
+    );
+    expect(ReactDomServer.renderToString).not.to.equal(undefined);
+    expect(typeof ReactDomServer.renderToString).to.equal("function");
+  });
+});

--- a/src/react-dom-server.browser.development.js
+++ b/src/react-dom-server.browser.development.js
@@ -1,0 +1,6 @@
+import ReactDOMServer from "react-dom/cjs/react-dom-server.browser.development.js";
+
+export default ReactDOMServer;
+export * from "react-dom/cjs/react-dom-server.browser.development.js";
+// This file exists simply to apply __esModule: true to the module
+export const __esModule = true;

--- a/src/react-dom-server.browser.production.min.js
+++ b/src/react-dom-server.browser.production.min.js
@@ -1,0 +1,6 @@
+import ReactDOMServer from "react-dom/cjs/react-dom-server.browser.production.min.js";
+
+export default ReactDOMServer;
+export * from "react-dom/cjs/react-dom-server.browser.production.min.js";
+// This file exists simply to apply __esModule: true to the module
+export const __esModule = true;


### PR DESCRIPTION
We ran into a problem where we need react-dom server (rich text) and I remembered that we also included it in the import-map at Canopy.
