### PR TITLE
fix npm install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ https://unpkg.com/@esm-bundle/react-dom/system/react-dom.development.js
 ## Npm
 
 ```sh
-npm install rxjs@npm:@esm-bundle/react-dom
+npm install react-dom@npm:@esm-bundle/react-dom
 ```
 
 ## Yarn


### PR DESCRIPTION
Presumably the mention of **rxjs** was a mistake, so changed it to **react-dom**.